### PR TITLE
chore: net10 bump

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,16 +6,18 @@ on:
       - main
   workflow_call:
 
+env:
+  DOTNET_VERSION: "10.x"
 jobs:
   build-tradingview:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - name: Setup .NET Core SDK 6.0.x
-        uses: actions/setup-dotnet@v3
+      - uses: actions/checkout@v4
+      - name: Setup .NET Core SDK ${{ env.DOTNET_VERSION }}
+        uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 7.0.x
-      - uses: actions/cache@v3
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+      - uses: actions/cache@v4
         with:
           path: ~/.nuget/packages
           # Look to see if there is a cache hit for the corresponding requirements file
@@ -29,7 +31,7 @@ jobs:
       - name: Build
         run: dotnet build -v=q --configuration Release --no-restore
       - name: Test
-        run: dotnet test --no-restore --logger trx --results-directory TestResults
+        run: dotnet test --no-restore --no-build --logger trx --results-directory TestResults
       - name: Check Test File Exists
         if: success() || failure()
         id: hasTests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,7 @@ on:
 
 env:
   NUGET_ENABLE_LEGACY_CSPROJ_PACK: true
+  DOTNET_VERSION: "10.x"
 
 jobs:
   bump-version:
@@ -41,17 +42,17 @@ jobs:
       GH_TOKEN: ${{ github.token }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup NuGet
         uses: NuGet/setup-nuget@v1
         with:
           nuget-version: "latest"
 
-      - name: Setup .NET Core SDK 7.0.x
-        uses: actions/setup-dotnet@v3
+      - name: Setup .NET Core SDK ${{ env.DOTNET_VERSION }}
+        uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 7.0.x
+          dotnet-version: ${{ env.DOTNET_VERSION }}
 
       - name: Add Github Package Source
         run: dotnet nuget add source --username DEMGroup --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name github.com "https://nuget.pkg.github.com/DEMGroup/index.json"
@@ -78,7 +79,7 @@ jobs:
     env:
       GH_TOKEN: ${{ github.token }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: git fetch --prune --unshallow --tags
       - name: Push New Tag (temp manual because actions-ecosystem/action-push-tag@v1 is broken)
         run: |

--- a/Aesir.TradingView.Tests/Aesir.TradingView.Tests.csproj
+++ b/Aesir.TradingView.Tests/Aesir.TradingView.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 
@@ -9,14 +9,14 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
-        <PackageReference Include="Moq" Version="4.18.4" />
-        <PackageReference Include="xunit" Version="2.4.2" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+        <PackageReference Include="Moq" Version="4.20.72" />
+        <PackageReference Include="xunit" Version="2.9.3" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="3.1.2">
+        <PackageReference Include="coverlet.collector" Version="6.0.4">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/Aesir.TradingView.Tests/Client/TradingViewClientTests.cs
+++ b/Aesir.TradingView.Tests/Client/TradingViewClientTests.cs
@@ -32,7 +32,7 @@ public class TradingViewClientTests
                 new SignalResponse
                 {
                     Symbol = "BINANCE:BTCUSDT",
-                    Signals = new[] { 500M, 510M }
+                    Signals = new decimal?[] { 500M, 510M }
                 }
             }
         });
@@ -74,7 +74,7 @@ public class TradingViewClientTests
                 new SignalResponse
                 {
                     Symbol = "BINANCE:BTCUSDT",
-                    Signals = new[] { 500M, 510M }
+                    Signals = new decimal?[] { 500M, 510M }
                 }
             }
         });
@@ -100,7 +100,7 @@ public class TradingViewClientTests
                 new SignalResponse
                 {
                     Symbol = "BINANCE:BTCUSDT",
-                    Signals = new[] { 500M, 510M }
+                    Signals = new decimal?[] { 500M, 510M }
                 }
             }
         });
@@ -123,7 +123,7 @@ public class TradingViewClientTests
                 new SignalResponse
                 {
                     Symbol = "BINANCE:BTCUSDT",
-                    Signals = new[] { 500M }
+                    Signals = new decimal?[] { 500M }
                 }
             }
         });

--- a/Aesir.TradingView/Aesir.TradingView.csproj
+++ b/Aesir.TradingView/Aesir.TradingView.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>


### PR DESCRIPTION
This pull request updates the project to target .NET 10 and modernizes the CI/CD workflows. It also upgrades key test dependencies and makes minor adjustments to test code for compatibility.

**.NET Version Upgrade:**

* Updated the target framework in both `Aesir.TradingView.csproj` and `Aesir.TradingView.Tests.csproj` from `net7.0` to `net10.0`. [[1]](diffhunk://#diff-7cc7b477c7e4977d108da7ab3afd27e9f66e0aa72ce9e1d572d6319813496b2dL4-R4) [[2]](diffhunk://#diff-ba103bf8b5ed74cbd586b175c5ff8d87138b1df586e061bfcbb04c3015ee653dL4-R19)
* Changed the default .NET version in GitHub Actions workflows (`build.yml`, `release.yml`) to use `10.x` via a new `DOTNET_VERSION` environment variable. [[1]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R9-R20) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R24)

**Dependency Upgrades (Testing):**

* Upgraded several test dependencies in `Aesir.TradingView.Tests.csproj`, including `Microsoft.NET.Test.Sdk`, `Moq`, `xunit`, `xunit.runner.visualstudio`, and `coverlet.collector`, to their latest versions.

**CI/CD Workflow Improvements:**

* Updated GitHub Actions to use the latest versions of `actions/checkout`, `actions/setup-dotnet`, and `actions/cache` (moved from v3 to v4). Also switched to using the environment variable for the .NET version in all relevant steps. [[1]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R9-R20) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L44-R55) [[3]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L81-R82)

**Test Code Adjustments:**

* Updated test code to use `decimal?[]` instead of `decimal[]` for the `Signals` property in several unit tests to match the expected type. [[1]](diffhunk://#diff-ebcbfbd7805fcb8e482e6d4b0ca76c844a4c8ec37c62bb3a75a75659fd4aca5eL35-R35) [[2]](diffhunk://#diff-ebcbfbd7805fcb8e482e6d4b0ca76c844a4c8ec37c62bb3a75a75659fd4aca5eL77-R77) [[3]](diffhunk://#diff-ebcbfbd7805fcb8e482e6d4b0ca76c844a4c8ec37c62bb3a75a75659fd4aca5eL103-R103) [[4]](diffhunk://#diff-ebcbfbd7805fcb8e482e6d4b0ca76c844a4c8ec37c62bb3a75a75659fd4aca5eL126-R126)
* Added `--no-build` to the `dotnet test` command in the build workflow to avoid redundant builds.